### PR TITLE
Adds: Fallback if opts.attach.selector is empty

### DIFF
--- a/Source/jBox.js
+++ b/Source/jBox.js
@@ -923,7 +923,7 @@ function jBox(type, options) {
 
 // Attach jBox to elements
 jBox.prototype.attach = function(elements, trigger) {
-	elements || (elements = jQuery(this.options.attach.selector));
+	elements || (elements = jQuery(this.options.attach.selector || this.options.attach));
 	trigger || (trigger = this.options.trigger);
 	
 	elements && elements.length && jQuery.each(elements, function(index, el) {


### PR DESCRIPTION
If jbox.options.attach.selector equals "" ( which is the case when used like this $('p').first().jBox(...) ) it will fallback to whatever this.options.attach is set to (in that case mentioned to "$('p').first()").

I'm scratching my head why you relate on that selector thing or if that was even on purpose. The only reason that comes into my mind is you want to have it working if attached elements are regularly getting replaced with new created ones but even then the selector eventually will have a given context that is not a string (e.g. $('p', '.first') will just return p(s) in $('.first'), has a context of document and the origin context is merged into the selector that is '.first p' while $('p', $('.first')[0]), will have the same result but has a context of HTMLElement and the selector alone is 'p' and thus not enough to build a correct set of elements). Also since jbox is only attached once at creation time that will not cover it I guess.

By passing options.attach directly into jquery you will enable constructs like 

``` js
$('p').each(function () {
    $(this).closest('.first').length && new jBox(... ,attach: this }); 
});
```

or

``` js
$('.btn').click(function () { $(this).jBox(...) })
```

to work as intended. I know the first one isn't really useful but you get the point :)

I'd also remove that attach.selector thing completely since it's imo not something to relate completely on but that is up to you.
