### PR TITLE
Updates: Unique ID generation

### DIFF
--- a/Source/jBox.js
+++ b/Source/jBox.js
@@ -341,9 +341,7 @@ function jBox(type, options) {
 	
 	// Get unique ID
 	if (this.options.id === null) {
-		var i = 1;
-		while (jQuery('#jBox' + i).length != 0) i++;
-		this.options.id = 'jBox' + i;
+		this.options.id = 'jBox' + jBox._getUID();
 	}
 	this.id = this.options.id;
 	
@@ -1382,6 +1380,13 @@ jBox.prototype.destroy = function() {
 	this.wrapper.remove();
 	return this;
 };
+
+jBox._getUID = (function () {
+    	var i = 1;
+    	return function () {
+		return i++;
+    	};
+}());
 
 // Make jBox usable with jQuery selectors
 jQuery.fn.jBox = function(type, options) {


### PR DESCRIPTION
Since a jbox may be not instantly injected into the DOM we will end up with some jboxes that have the same id since the old method was relating on the DOM. That way you will have racing conditions between when a new jbox is created and when another one is added to the DOM.

Fixed that by using a static closure that will return an integer that is increased by one everytime it is getting called. I'll admit it won't catch deleted jboxes like your method but relating on really unique IDs is probably better than having several jboxes with the same id that eventually will mess when this.id is used.
