### PR TITLE
setContent() with a jquery selector

### DIFF
--- a/Source/jBox.js
+++ b/Source/jBox.js
@@ -1104,7 +1104,7 @@ jBox.prototype.setContent = function(content, ignore_positioning) {
 	// Set the new content
 	switch (jQuery.type(content)) {
 		case 'string': this.content.html(content); break;
-		case 'object': this.content.children().css({display: 'none'}); this.options.content.appendTo(this.content).css({display: 'block'}); break;
+		case 'object': this.content.children().css({display: 'none'}); content.appendTo(this.content).css({display: 'block'}); break;
 	}
 	
 	// Calculate the difference to before the content was set


### PR DESCRIPTION
Hello,

I think there is a little mistake in case of using setContent() with a jquery selector as argument.
It produce a javascript error: "Uncaught TypeError: Cannot read property 'appendTo' of null".
