### PR TITLE
Reposition all notices on positioned event (when their width has been…

### DIFF
--- a/Demo/Demo.js
+++ b/Demo/Demo.js
@@ -254,6 +254,7 @@ $('#Notice-5').click(function() {
   new jBox('Notice', {
     content: 'Hover me, I\'ll stick around',
     color: 'black',
+    autoClose: Math.random() * 8000 + 2000,
     delayOnHover: true
   });
   
@@ -265,6 +266,7 @@ $('#Notice-6').click(function() {
   new jBox('Notice', {
     animation: 'flip',
     color: getColor(),
+    autoClose: Math.random() * 8000 + 2000,
     content: 'Oooh! They also come in colors',
     delayOnHover: true,
     showCountdown: true,
@@ -283,9 +285,12 @@ $('#Notice-7').click(function() {
       y: 'bottom'
     },
     color: getColor(),
-    content: 'Hello, I\'m down here',
+    content: getString(),
+    title: getTitle(),
+    maxWidth: 600,
     audio: '../Source/audio/bling2',
     volume: 80,
+    autoClose: Math.random() * 8000 + 2000,
     animation: {open: 'slide:bottom', close: 'slide:left'},
     delayOnHover: true,
     showCountdown: true,
@@ -307,6 +312,7 @@ $('#Notice-8').click(function() {
       open: 'tada',
       close: 'zoomIn'
     },
+    autoClose: Math.random() * 8000 + 2000,
     color: getColor(),
     title: 'Tadaaa! I\'m single',
     content: 'Open another notice, I won\'t stack',
@@ -346,6 +352,16 @@ var colors = ['red', 'green', 'blue', 'yellow'], index = 0;
 var getColor = function () {
   (index >= colors.length) && (index = 0);
   return colors[index++];
+};
+
+var strings = ['Short', 'You just switched the internet off', 'Please do not click too hard - next time we\'ll notify google.', 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.'];
+var getString = function () {
+  return strings[Math.floor(Math.random()*strings.length)];
+};
+
+var titles = ['Congrats', 'Success', 'Thank you', false, false, false];
+var getTitle = function () {
+  return titles[Math.floor(Math.random()*strings.length)];
 };
 
 


### PR DESCRIPTION
My last pull request exposed a pre-existing problem: If notices do not close in the same order they were opened (due to different autoClose delays, or now due to delayOnHover) they should reposition themselves.

This also fixes a problem with notices with maxWidth set overlapping - because they were stacked before the maxWidth was applied... I think.

This repositions notices exactly as I think it should... but I'm not entirely sure this is the "correct" implementation (ie. the correct hooks etc.), which is why I wanted to make separate pull requests.

Let me know what you think.