### PR TITLE
[🔥 Broken Release Patch 🔥] Fix typo in jBox.d.ts

### DIFF
--- a/src/js/jBox.d.ts
+++ b/src/js/jBox.d.ts
@@ -198,7 +198,7 @@ declare namespace jBox {
     onOpen?: () => void;
 
     /** Fired when jBox is completely open (when fading is finished) */
-    onCloseComplete?: () => void;
+    onOpenComplete?: () => void;
 
     /** Fired when jBox closes */
     onClose?: () => void;


### PR DESCRIPTION
`v1.3.1` is broken (for TypeScript) because of this commit:

https://github.com/StephanWagner/jBox/commit/e4bd88720b8088c6832841874917929727a8198b