### PR TITLE
Fixed dependency on jQuery.type (deprecated)

### DIFF
--- a/dist/jBox.js
+++ b/dist/jBox.js
@@ -195,7 +195,7 @@ function jBoxWrapper(jQuery) {
 
     // Set the jBox type
 
-    jQuery.type(type) == 'string' && (this.type = type);
+    typeof(type) === 'string' && (this.type = type);
 
 
     // Checks if the user is on a touch device, borrowed from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/touchevents.js


### PR DESCRIPTION
Changed jQuery.type to typeof.

Fix for issue: #189 